### PR TITLE
Add obsolete attribute for deprecated endpoint(s)

### DIFF
--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -44,6 +44,7 @@ namespace DiscordBotsList.Api
 		/// </summary>
 		/// <param name="days">Amount of days to filter</param>
 		/// <returns>A list of snowflakes</returns>
+		[Obsolete("This endpoint has been deprecated")]
 		public async Task<List<ulong>> GetVoterIdsAsync(int? days)
 			=> await GetVotersAsync<ulong>(days);
 


### PR DESCRIPTION
People get exceptions from the deprecated endpoints.
Removing the method would break the code of existing applications, even if they don't use the endpoint anymore.

I'd suggest a new major version indicating a major change and removing the method and adjusting the unit tests.

For now the Obsolete keyword will give them a warning. 