### PR TITLE
Improve UpdateStats

### DIFF
--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -68,6 +68,20 @@ namespace DiscordBotsList.Api
         }
 
         /// <summary>
+        /// Update your stats sharded
+        /// </summary>
+        /// <param name="guildCount">count of guilds</param>
+        /// <param name="shardCount">Total shards</param>
+        public async Task UpdateStats(int guildCount, int shardCount)
+        {
+            await UpdateStatsAsync(new ShardedGuildCountObject
+            {
+                ShardCount = shardCount,
+                GuildCount = guildCount
+            });
+        }
+
+        /// <summary>
         /// returns true if user have voted for the past 12 hours
         /// </summary>
         /// <param name="userId">Amount of days to filter</param>

--- a/DiscordBotsList.Api/Internal/GuildCountObject.cs
+++ b/DiscordBotsList.Api/Internal/GuildCountObject.cs
@@ -47,5 +47,8 @@ namespace DiscordBotsList.Api.Internal
 
 		[JsonProperty("shard_count")]
 		public int ShardCount;
+
+		[JsonProperty("server_count")]
+		public int GuildCount;
 	}
 }


### PR DESCRIPTION
The DBL API does not require that shardId, shardCount, and shards for some requests.
This makes it simple to update the shard count and guild count for small bots.