### PR TITLE
Remove Miki.Net.Http

### DIFF
--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -105,7 +105,7 @@ namespace DiscordBotsList.Api
             var json = JsonConvert.SerializeObject(statsObject);
             var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
             await _httpClient
-                .PostAsync($"https://discordbots.org/api/bots/{_selfId}/stats", httpContent);
+                .PostAsync($"{baseEndpoint}/bots/{_selfId}/stats", httpContent);
         }
 
         protected async Task<T> GetAuthorizedAsync<T>(string url)
@@ -115,7 +115,7 @@ namespace DiscordBotsList.Api
 
         protected async Task<bool> HasVotedAsync(ulong userId)
         {
-            var url = "bots/" + $"{_selfId}/check?userId={userId}";
+            var url = $"bots/{_selfId}/check?userId={userId}";
             return (await GetAsync<dynamic>(url)).voted.ToString().Equals("1");
         }
     }

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 using DiscordBotsList.Api.Internal;
 using DiscordBotsList.Api.Objects;
@@ -18,7 +21,7 @@ namespace DiscordBotsList.Api
             _selfId = selfId;
             _token = token;
 
-			_httpClient.SetAuthorization(_token);
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
         /// <summary>
@@ -100,26 +103,20 @@ namespace DiscordBotsList.Api
         protected async Task UpdateStatsAsync(object statsObject)
         {
             var json = JsonConvert.SerializeObject(statsObject);
-
+            var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
             await _httpClient
-                .PostAsync($"bots/{_selfId}/stats", json);
+                .PostAsync($"https://discordbots.org/api/bots/{_selfId}/stats", httpContent);
         }
 
         protected async Task<T> GetAuthorizedAsync<T>(string url)
         {
-            var t = await _httpClient
-                .GetAsync<T>(url);
-            if (t.Success) return t.Data;
-            return default(T);
+            return await GetAsync<T>(url);
         }
 
         protected async Task<bool> HasVotedAsync(ulong userId)
         {
-            var url = "https://discordbots.org/api/bots/" + $"{_selfId}/check?userId={userId}";
-            var response = await _httpClient.GetAsync(url);
-            var jsonString = response.Body;
-            var dynObj = JsonConvert.DeserializeObject<dynamic>(jsonString);
-            return dynObj.voted.ToString().Equals("1");
+            var url = "bots/" + $"{_selfId}/check?userId={userId}";
+            return (await GetAsync<dynamic>(url)).voted.ToString().Equals("1");
         }
     }
 }

--- a/DiscordBotsList.Api/DiscordBotListApi.cs
+++ b/DiscordBotsList.Api/DiscordBotListApi.cs
@@ -1,10 +1,9 @@
 ﻿using DiscordBotsList.Api.Internal;
 using DiscordBotsList.Api.Internal.Queries;
-using Miki.Rest;
 using System.Threading.Tasks;
 using DiscordBotsList.Api.Objects;
+using System.Net.Http;
 using Newtonsoft.Json;
-using Miki.Net.Http;
 
 namespace DiscordBotsList.Api
 {
@@ -14,7 +13,7 @@ namespace DiscordBotsList.Api
 
 		public DiscordBotListApi()
 		{
-			_httpClient = new HttpClient("https://discordbots.org/api/");
+            _httpClient = new HttpClient();
 		}
 
 		/// <summary>
@@ -80,12 +79,10 @@ namespace DiscordBotsList.Api
 		/// <returns>Object of type T</returns>
 		protected async Task<T> GetAsync<T>(string url)
 		{
-			HttpResponse<T> t = await _httpClient.GetAsync<T>(url);
-			if (t.Success)
-			{
-				return t.Data;
-			}
-			return default(T);
+			HttpResponseMessage t = await _httpClient.GetAsync("https://discordbots.org/api/" + url);
+            if (t.IsSuccessStatusCode)
+				return JsonConvert.DeserializeObject<T>(await t.Content.ReadAsStringAsync());
+			return default;
 		}
 
 	    /// <summary>
@@ -93,6 +90,6 @@ namespace DiscordBotsList.Api
 	    /// </summary>
 	    /// <returns>True or False</returns>
 	    public async Task<bool> IsWeekendAsync()
-			=> (await _httpClient.GetAsync<WeekendObject>("weekend")).Data.Weekend;
+			=> (await GetAsync<WeekendObject>("weekend")).Weekend;
 	}
 }

--- a/DiscordBotsList.Api/DiscordBotListApi.cs
+++ b/DiscordBotsList.Api/DiscordBotListApi.cs
@@ -10,6 +10,7 @@ namespace DiscordBotsList.Api
 	public class DiscordBotListApi
 	{
 		protected HttpClient _httpClient;
+        protected const string baseEndpoint = "https://discordbots.org/api/";
 
 		public DiscordBotListApi()
 		{
@@ -79,7 +80,7 @@ namespace DiscordBotsList.Api
 		/// <returns>Object of type T</returns>
 		protected async Task<T> GetAsync<T>(string url)
 		{
-			HttpResponseMessage t = await _httpClient.GetAsync("https://discordbots.org/api/" + url);
+			HttpResponseMessage t = await _httpClient.GetAsync(baseEndpoint + url);
             if (t.IsSuccessStatusCode)
 				return JsonConvert.DeserializeObject<T>(await t.Content.ReadAsStringAsync());
 			return default;

--- a/DiscordBotsList.Api/DiscordBotsList.Api.csproj
+++ b/DiscordBotsList.Api/DiscordBotsList.Api.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Miki.Net.Http" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi,
I'm using DBL-dotnet-library for a bot but I find it a bit annoying to install a new dependency (Miki.Net.Http) so I made this pull request to use System.HttpClient instead.