### PR TITLE
Create catcher for JSON errors (#5)

### DIFF
--- a/DiscordBotsList.Api/DiscordBotListApi.cs
+++ b/DiscordBotsList.Api/DiscordBotListApi.cs
@@ -99,27 +99,4 @@ namespace DiscordBotsList.Api
 	    public async Task<bool> IsWeekendAsync()
 			=> (await GetAsync<WeekendObject>("weekend")).Weekend;
 	}
-	
-	public class ApiResult<T>
-	{
-		private ApiResult() {}
-		
-		internal static ApiResult<T> FromSuccess(T value)
-			=> new ApiResult<T> { Value = value, IsSuccess = true };
-		
-		internal static ApiResult<T> FromError(Exception ex)
-			=> new ApiResult<T> { Value = default, ErrorReason = ex.Message, IsSuccess = false };
-		
-		internal static ApiResult<T> FromHttpError(HttpStatusCode statusCode) // This could be altered to collect an object that provides more information
-			=> new ApiResult<T> { Value = default, ErrorReason = code.ToString(), IsSuccess = false } ;
-		
-		public T Value { get; private set; }
-		
-		/// <summary>
-		/// The error reason for this API request, if any.
-		/// </summary>
-		public string ErrorReason { get; private set; }
-		
-		public bool IsSuccess { get; private set; }
-	}
 }

--- a/DiscordBotsList.Api/Objects/ApiRequest.cs
+++ b/DiscordBotsList.Api/Objects/ApiRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net;
+
+namespace DiscordBotsList.Api.Objects
+{
+    public class ApiResult<T>
+	  {
+		private ApiResult() {}
+		
+		internal static ApiResult<T> FromSuccess(T value)
+		    	=> new ApiResult<T> { Value = value, IsSuccess = true };
+		
+		internal static ApiResult<T> FromError(Exception ex)
+		    	=> new ApiResult<T> { Value = default, ErrorReason = ex.Message, IsSuccess = false };
+		
+		internal static ApiResult<T> FromHttpError(HttpStatusCode statusCode) // This could be altered to collect an object that provides more information
+	    		=> new ApiResult<T> { Value = default, ErrorReason = code.ToString(), IsSuccess = false } ;
+		
+	    	public T Value { get; private set; }
+		
+	    	/// <summary>
+    		/// The error reason for this API request, if any.
+    		/// </summary>
+	    	public string ErrorReason { get; private set; }
+	        	
+	    	public bool IsSuccess { get; private set; }
+	 }
+}


### PR DESCRIPTION
Hoping I did this correctly (first pull request). This should now gracefully catch whenever a JSON request returns empty. If wanted, this can now be passed on through each request to give the user the ability to handle when an error occurs. As of now, it returns the default value of the object requested on error. As a side note, I also slightly cleaned up some of the code presented in DiscordBotListApi.cs.