### PR TITLE
feat: adapt to v0

### DIFF
--- a/DiscordBotsList.Api.Adapter.Discord.Net/DiscordBotsList.Api.Adapter.Discord.Net.csproj
+++ b/DiscordBotsList.Api.Adapter.Discord.Net/DiscordBotsList.Api.Adapter.Discord.Net.csproj
@@ -2,23 +2,23 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Authors>Velddev, Faith Viola</Authors>
+        <Authors>Velddev, Faith</Authors>
         <Company>Top.gg</Company>
         <Product>DiscordBotsList.Api.Adapter.Discord.Net</Product>
-        <Description>Adapter for Discord.Net</Description>
+        <Description>Top.gg API adapter for Discord.Net</Description>
         <PackageReleaseNotes>Initial release</PackageReleaseNotes>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Mike Veldsink</Copyright>
-        <PackageTags>discord bots list org wrapper api discord.net</PackageTags>
+        <PackageTags>discord bots topgg api discord.net</PackageTags>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/DiscordBotList/DBL-dotnet-Library</RepositoryUrl>
-        <PackageProjectUrl>https://github.com/DiscordBotList/DBL-dotnet-Library</PackageProjectUrl>
-        <Version>1.5.0</Version>
+        <RepositoryUrl>https://github.com/Top-gg-Community/dotnet-sdk</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/Top-gg-Community/dotnet-sdk</PackageProjectUrl>
+        <Version>2.0.0</Version>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Discord.Net" Version="2.4.0"/>
+        <PackageReference Include="Discord.Net" Version="3.17.4"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/DiscordBotsList.Api.Adapter.Discord.Net/DiscordBotsList.Api.Adapter.Discord.Net.csproj
+++ b/DiscordBotsList.Api.Adapter.Discord.Net/DiscordBotsList.Api.Adapter.Discord.Net.csproj
@@ -13,7 +13,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Top-gg-Community/dotnet-sdk</RepositoryUrl>
         <PackageProjectUrl>https://github.com/Top-gg-Community/dotnet-sdk</PackageProjectUrl>
-        <Version>2.0.0</Version>
+        <Version>1.6.0</Version>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
 

--- a/DiscordBotsList.Api.Tests/DiscordBotsList.Api.Tests.csproj
+++ b/DiscordBotsList.Api.Tests/DiscordBotsList.Api.Tests.csproj
@@ -8,22 +8,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Remove="settings.json"/>
+        <None Remove="settings.json" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1"/>
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DiscordBotsList.Api\DiscordBotsList.Api.csproj"/>
+        <ProjectReference Include="..\DiscordBotsList.Api\DiscordBotsList.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DiscordBotsList.Api.Tests/UnitTests.cs
+++ b/DiscordBotsList.Api.Tests/UnitTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,10 +11,11 @@ namespace DiscordBotsList.Api.Tests
 
         public static Credentials LoadFromEnv()
         {
-            var cred = new Credentials();
-            cred.BotId = ulong.Parse(Environment.GetEnvironmentVariable("BOT_ID"));
-            cred.Token = Environment.GetEnvironmentVariable("API_KEY");
-            return cred;
+            return new Credentials()
+            {
+                BotId = ulong.Parse(Environment.GetEnvironmentVariable("BOT_ID")),
+                Token = Environment.GetEnvironmentVariable("API_KEY")
+            };
         }
     }
 
@@ -28,13 +28,6 @@ namespace DiscordBotsList.Api.Tests
         {
             _cred = Credentials.LoadFromEnv();
             _api = new AuthDiscordBotListApi(_cred.BotId, _cred.Token);
-        }
-
-        [Fact]
-        public void GetUserTest()
-        {
-            Assert.NotNull(_api.GetMeAsync());
-            Assert.NotNull(_api.GetUserAsync(_cred.BotId));
         }
 
         [Fact]
@@ -56,15 +49,9 @@ namespace DiscordBotsList.Api.Tests
         }
 
         [Fact]
-        public async Task GetUserTestAsync()
-        {
-            Assert.NotNull(await _api.GetUserAsync(181514288278536193));
-        }
-
-        [Fact]
         public async Task GetBotTestAsync()
         {
-            var botId = 423593006436712458U;
+            var botId = 1026525568344264724U;
             var bot = await _api.GetBotAsync(botId);
             Assert.NotNull(bot);
             Assert.Equal(botId, bot.Id);
@@ -83,12 +70,6 @@ namespace DiscordBotsList.Api.Tests
 
             Assert.NotNull(bots);
             Assert.NotEmpty(bots.Items);
-
-            var firstBot = bots.Items.First();
-
-            var stats = await firstBot.GetStatsAsync();
-
-            Assert.NotNull(stats);
         }
     }
 }

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -22,12 +22,10 @@ namespace DiscordBotsList.Api
     public class AuthDiscordBotListApi : DiscordBotListApi
     {
         private readonly ulong _selfId;
-        private readonly string _token;
 
         public AuthDiscordBotListApi(ulong selfId, string token)
         {
             _selfId = selfId;
-            _token = token;
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
@@ -44,6 +42,7 @@ namespace DiscordBotsList.Api
             sortByString = char.ToLowerInvariant(sortByString[0]) + sortByString[1..];
 
             var result = await GetAsync<BotListQuery>($"bots?limit={count}&offset={offset}&sort={sortByString}");
+
             foreach (var bot in result.Items) (bot as Bot).api = this;
             return result;
         }
@@ -177,9 +176,9 @@ namespace DiscordBotsList.Api
                 .PostAsync($"{baseEndpoint}/bots/{_selfId}/stats", httpContent);
         }
 
-        protected async Task<T> GetAuthorizedAsync<T>(string url)
+        protected Task<T> GetAuthorizedAsync<T>(string url)
         {
-            return await GetAsync<T>(url);
+            return GetAsync<T>(url);
         }
 
         protected async Task<bool> HasVotedAsync(ulong userId)

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -1,6 +1,7 @@
 ﻿using DiscordBotsList.Api.Internal;
 using DiscordBotsList.Api.Internal.Queries;
 using DiscordBotsList.Api.Objects;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -75,11 +76,11 @@ namespace DiscordBotsList.Api
         /// <summary>
         ///     Get bot stats
         /// </summary>
-        /// <param name="id">Discord id</param>
+        /// <param name="id">Discord id, no longer needed</param>
         /// <returns>IBotStats object related to the bot</returns>
-        public new async Task<IDblBotStats> GetBotStatsAsync(ulong id)
+        public new async Task<IDblBotStats> GetBotStatsAsync(ulong id = 0)
         {
-            return await GetAsync<BotStatsObject>($"bots/{id}/stats");
+            return await GetAsync<BotStatsObject>($"bots/{_selfId}/stats");
         }
 
         /// <summary>
@@ -104,13 +105,13 @@ namespace DiscordBotsList.Api
         }
 
         /// <summary>
-        ///     Gets all voters that have voted on your bot
-        ///     Max 1000, If you have more, you MUST use WEBHOOKS instead.
+        ///     Fetches unique voters that have voted for your project
         /// </summary>
+        /// <param name="page">The page number, defaults to 1</param>
         /// <returns>A list of voters</returns>
-        public async Task<List<IDblEntity>> GetVotersAsync()
+        public async Task<List<IDblEntity>> GetVotersAsync(int page = 1)
         {
-            return (await GetVotersAsync<Entity>()).Cast<IDblEntity>().ToList();
+            return (await GetAsync<List<Entity>>($"bots/{_selfId}/votes?page={Math.Max(page, 1)}")).Cast<IDblEntity>().ToList();
         }
 
         /// <summary>

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -154,9 +154,9 @@ namespace DiscordBotsList.Api
         }
 
         /// <summary>
-        ///     returns true if user have voted for the past 12 hours
+        ///     returns true if the user has voted for your project in the past 12 hours
         /// </summary>
-        /// <param name="userId">Amount of days to filter</param>
+        /// <param name="userId">the user ID</param>
         /// <returns>True or False</returns>
         public async Task<bool> HasVoted(ulong userId)
         {

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -11,6 +11,13 @@ using System.Threading.Tasks;
 
 namespace DiscordBotsList.Api
 {
+    public enum SortBotsBy
+    {
+        MonthlyPoints,
+        Id,
+        Date,
+    }
+
     public class AuthDiscordBotListApi : DiscordBotListApi
     {
         private readonly ulong _selfId;
@@ -24,14 +31,18 @@ namespace DiscordBotsList.Api
         }
 
         /// <summary>
-        ///     Gets bots from botlist
+        ///     Fetches bots from Top.gg
         /// </summary>
-        /// <param name="count">amount of bots to appear per page (max: 500)</param>
-        /// <param name="page">current page to query</param>
+        /// <param name="count">amount of bots to retrieve (max: 500)</param>
+        /// <param name="offset">amount of bots to skip</param>
+        /// <param name="sortBy">sorts results based on their monthly vote count, id, or their submission date</param>
         /// <returns>List of Bot Objects</returns>
-        public new async Task<ISearchResult<IDblBot>> GetBotsAsync(int count = 50, int page = 0)
+        public async Task<ISearchResult<IDblBot>> GetBotsAsync(int count = 50, int offset = 0, SortBotsBy sortBy = SortBotsBy.MonthlyPoints)
         {
-            var result = await GetAsync<BotListQuery>("bots");
+            var sortByString = sortBy.ToString();
+            sortByString = char.ToLowerInvariant(sortByString[0]) + sortByString[1..];
+
+            var result = await GetAsync<BotListQuery>($"bots?limit={count}&offset={offset}&sort={sortByString}");
             foreach (var bot in result.Items) (bot as Bot).api = this;
             return result;
         }

--- a/DiscordBotsList.Api/AuthenticatedBotListApi.cs
+++ b/DiscordBotsList.Api/AuthenticatedBotListApi.cs
@@ -1,4 +1,5 @@
 ﻿using DiscordBotsList.Api.Internal;
+using DiscordBotsList.Api.Internal.Queries;
 using DiscordBotsList.Api.Objects;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,6 +21,64 @@ namespace DiscordBotsList.Api
             _selfId = selfId;
             _token = token;
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        /// <summary>
+        ///     Gets bots from botlist
+        /// </summary>
+        /// <param name="count">amount of bots to appear per page (max: 500)</param>
+        /// <param name="page">current page to query</param>
+        /// <returns>List of Bot Objects</returns>
+        public new async Task<ISearchResult<IDblBot>> GetBotsAsync(int count = 50, int page = 0)
+        {
+            var result = await GetAsync<BotListQuery>("bots");
+            foreach (var bot in result.Items) (bot as Bot).api = this;
+            return result;
+        }
+
+        /// <summary>
+        ///     Template
+        ///     of GetBotAsync for internal usage.
+        /// </summary>
+        /// <typeparam name="T">Type of Bot</typeparam>
+        /// <param name="id">Discord id</param>
+        /// <returns>Bot object of type T</returns>
+        internal async Task<T> GetBotAsync<T>(ulong id) where T : Bot
+        {
+            var t = await GetAsync<T>($"bots/{id}");
+            if (t == null) return null;
+            t.api = this;
+            return t;
+        }
+
+        /// <summary>
+        ///     Get specific bot by Discord id
+        /// </summary>
+        /// <param name="id">Discord id</param>
+        /// <returns>Bot Object</returns>
+        public new async Task<IDblBot> GetBotAsync(ulong id)
+        {
+            return await GetBotAsync<Bot>(id);
+        }
+
+        /// <summary>
+        ///     Get bot stats
+        /// </summary>
+        /// <param name="id">Discord id</param>
+        /// <returns>IBotStats object related to the bot</returns>
+        public new async Task<IDblBotStats> GetBotStatsAsync(ulong id)
+        {
+            return await GetAsync<BotStatsObject>($"bots/{id}/stats");
+        }
+
+        /// <summary>
+        ///     Get specific user by Discord id
+        /// </summary>
+        /// <param name="id">Discord id</param>
+        /// <returns>User Object</returns>
+        public new async Task<IDblUser> GetUserAsync(ulong id)
+        {
+            return await GetAsync<User>($"users/{id}");
         }
 
         /// <summary>

--- a/DiscordBotsList.Api/DiscordBotListApi.cs
+++ b/DiscordBotsList.Api/DiscordBotListApi.cs
@@ -1,6 +1,6 @@
 ﻿using DiscordBotsList.Api.Internal;
-using DiscordBotsList.Api.Internal.Queries;
 using DiscordBotsList.Api.Objects;
+using System;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -12,7 +12,7 @@ namespace DiscordBotsList.Api
     {
         protected const string baseEndpoint = "https://top.gg/api/";
         private readonly JsonSerializerOptions _serializerOptions;
-        protected HttpClient _httpClient;
+        protected readonly HttpClient _httpClient;
 
         public DiscordBotListApi()
         {
@@ -27,11 +27,10 @@ namespace DiscordBotsList.Api
         /// <param name="count">amount of bots to appear per page (max: 500)</param>
         /// <param name="page">current page to query</param>
         /// <returns>List of Bot Objects</returns>
-        public async Task<ISearchResult<IDblBot>> GetBotsAsync(int count = 50, int page = 0)
+        [Obsolete("This method requires a token to work. Please use the AuthenticatedBotListApi class instead.", true)]
+        public Task<ISearchResult<IDblBot>> GetBotsAsync(int count = 50, int page = 0)
         {
-            var result = await GetAsync<BotListQuery>("bots");
-            foreach (var bot in result.Items) (bot as Bot).api = this;
-            return result;
+            return null;
         }
 
         /// <summary>
@@ -39,9 +38,10 @@ namespace DiscordBotsList.Api
         /// </summary>
         /// <param name="id">Discord id</param>
         /// <returns>Bot Object</returns>
-        public async Task<IDblBot> GetBotAsync(ulong id)
+        [Obsolete("This method requires a token to work. Please use the AuthenticatedBotListApi class instead.", true)]
+        public Task<IDblBot> GetBotAsync(ulong id)
         {
-            return await GetBotAsync<Bot>(id);
+            return null;
         }
 
         /// <summary>
@@ -49,9 +49,10 @@ namespace DiscordBotsList.Api
         /// </summary>
         /// <param name="id">Discord id</param>
         /// <returns>IBotStats object related to the bot</returns>
-        public async Task<IDblBotStats> GetBotStatsAsync(ulong id)
+        [Obsolete("This method requires a token to work. Please use the AuthenticatedBotListApi class instead.", true)]
+        public Task<IDblBotStats> GetBotStatsAsync(ulong id)
         {
-            return await GetAsync<BotStatsObject>($"bots/{id}/stats");
+            return null;
         }
 
         /// <summary>
@@ -59,24 +60,10 @@ namespace DiscordBotsList.Api
         /// </summary>
         /// <param name="id">Discord id</param>
         /// <returns>User Object</returns>
-        public async Task<IDblUser> GetUserAsync(ulong id)
+        [Obsolete("This method requires a token to work. Please use the AuthenticatedBotListApi class instead.", true)]
+        public Task<IDblUser> GetUserAsync(ulong id)
         {
-            return await GetAsync<User>($"users/{id}");
-        }
-
-        /// <summary>
-        ///     Template
-        ///     of GetBotAsync for internal usage.
-        /// </summary>
-        /// <typeparam name="T">Type of Bot</typeparam>
-        /// <param name="id">Discord id</param>
-        /// <returns>Bot object of type T</returns>
-        internal async Task<T> GetBotAsync<T>(ulong id) where T : Bot
-        {
-            var t = await GetAsync<T>($"bots/{id}");
-            if (t == null) return null;
-            t.api = this;
-            return t;
+            return null;
         }
 
         /// <summary>

--- a/DiscordBotsList.Api/DiscordBotsList.Api.csproj
+++ b/DiscordBotsList.Api/DiscordBotsList.Api.csproj
@@ -16,7 +16,7 @@
         <AssemblyName>DiscordBotsList.Api</AssemblyName>
         <RootNamespace>DiscordBotsList.Api</RootNamespace>
         <Product>DiscordBotsList.Api</Product>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
     </PropertyGroup>
 

--- a/DiscordBotsList.Api/DiscordBotsList.Api.csproj
+++ b/DiscordBotsList.Api/DiscordBotsList.Api.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DiscordBotsList.Api/DiscordBotsList.Api.csproj
+++ b/DiscordBotsList.Api/DiscordBotsList.Api.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Authors>Velddev, Faith Viola</Authors>
+        <Authors>Velddev, Faith</Authors>
         <Company>Top.gg</Company>
         <Description>top.gg api wrapper</Description>
         <Copyright>Mike Veldsink</Copyright>

--- a/DiscordBotsList.Api/Internal/Bot.cs
+++ b/DiscordBotsList.Api/Internal/Bot.cs
@@ -1,7 +1,6 @@
 ﻿using DiscordBotsList.Api.Objects;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
@@ -10,6 +9,10 @@ namespace DiscordBotsList.Api.Internal
     public class Bot : Entity, IDblBot
     {
         internal DiscordBotListApi api;
+
+        [JsonPropertyName("clientid")]
+        [JsonConverter(typeof(ULongToStringConverter))]
+        public ulong clientId { get; set; }
 
         [JsonPropertyName("prefix")] public string prefix { get; set; }
 
@@ -21,7 +24,9 @@ namespace DiscordBotsList.Api.Internal
 
         [JsonPropertyName("website")] public string websiteUrl { get; set; }
 
-        [JsonPropertyName("support")] public string SupportInviteCode { get; set; }
+        [JsonPropertyName("support")]
+        [Obsolete("Actually refers to the entire support invite URL, not just its invite code. Use SupportUrl instead.")]
+        public string SupportInviteCode { get; set; }
 
         [JsonPropertyName("github")] public string githubUrl { get; set; }
 
@@ -29,7 +34,11 @@ namespace DiscordBotsList.Api.Internal
 
         [JsonPropertyName("invite")] public string customInvite { get; set; }
 
-        [JsonPropertyName("date")] public DateTime approvedAt { get; set; }
+        [JsonPropertyName("date")]
+        [Obsolete("Actually refers to when the bot was submitted. Use submittedAt instead.")]
+        public DateTime approvedAt { get; set; }
+
+        [JsonPropertyName("date")] public DateTime submittedAt { get; set; }
 
         [JsonPropertyName("certifiedBot")] public bool certified { get; set; }
 
@@ -39,9 +48,15 @@ namespace DiscordBotsList.Api.Internal
         
         [JsonPropertyName("monthlyPoints")] public int monthlyPoints { get; set; }
 
+        [JsonPropertyName("reviews")]
+        public BotReviews reviews { get; set; }
+
         public string VanityTag => vanity;
 
-        public DateTime ApprovedAt => approvedAt;
+        [Obsolete("Actually refers to when the bot was submitted. Use SubmittedAt instead.")]
+        public DateTime ApprovedAt => submittedAt;
+
+        public DateTime SubmittedAt => submittedAt;
 
         public string GithubUrl => githubUrl;
 
@@ -53,7 +68,7 @@ namespace DiscordBotsList.Api.Internal
 
         public string PrefixUsed => prefix;
 
-        public List<ulong> OwnerIds => owners.ToList();
+        public List<ulong> OwnerIds => owners;
 
         public int Points => points;
         
@@ -61,10 +76,12 @@ namespace DiscordBotsList.Api.Internal
 
         public string ShortDescription => shortDescription;
 
-        public List<string> Tags => tags.ToList();
+        public List<string> Tags => tags;
 
-        public string SupportUrl => "https://discord.gg/" + SupportInviteCode;
-        
+#pragma warning disable CS0618
+        public string SupportUrl => SupportInviteCode;
+#pragma warning restore CS0618
+
         public string VanityUrl => "https://top.gg/bot/" + vanity;
 
         public string WebsiteUrl => websiteUrl;

--- a/DiscordBotsList.Api/Internal/Bot.cs
+++ b/DiscordBotsList.Api/Internal/Bot.cs
@@ -51,6 +51,8 @@ namespace DiscordBotsList.Api.Internal
         [JsonPropertyName("reviews")]
         public BotReviews reviews { get; set; }
 
+        public ulong ClientId => clientId;
+
         public string VanityTag => vanity;
 
         [Obsolete("Actually refers to when the bot was submitted. Use SubmittedAt instead.")]
@@ -85,6 +87,8 @@ namespace DiscordBotsList.Api.Internal
         public string VanityUrl => "https://top.gg/bot/" + vanity;
 
         public string WebsiteUrl => websiteUrl;
+
+        public BotReviews Reviews => reviews;
 
         public async Task<IDblBotStats> GetStatsAsync()
         {

--- a/DiscordBotsList.Api/Internal/Bot.cs
+++ b/DiscordBotsList.Api/Internal/Bot.cs
@@ -34,9 +34,8 @@ namespace DiscordBotsList.Api.Internal
 
         [JsonPropertyName("invite")] public string customInvite { get; set; }
 
-        [JsonPropertyName("date")]
         [Obsolete("Actually refers to when the bot was submitted. Use submittedAt instead.")]
-        public DateTime approvedAt { get; set; }
+        public DateTime approvedAt => submittedAt;
 
         [JsonPropertyName("date")] public DateTime submittedAt { get; set; }
 

--- a/DiscordBotsList.Api/Internal/Bot.cs
+++ b/DiscordBotsList.Api/Internal/Bot.cs
@@ -92,7 +92,7 @@ namespace DiscordBotsList.Api.Internal
 
         public async Task<IDblBotStats> GetStatsAsync()
         {
-            return await api.GetBotStatsAsync(Id);
+            return await ((AuthDiscordBotListApi)api).GetBotStatsAsync(Id);
         }
     }
 }

--- a/DiscordBotsList.Api/Internal/Bot.cs
+++ b/DiscordBotsList.Api/Internal/Bot.cs
@@ -25,8 +25,10 @@ namespace DiscordBotsList.Api.Internal
         [JsonPropertyName("website")] public string websiteUrl { get; set; }
 
         [JsonPropertyName("support")]
+        public string supportUrl { get; set; }
+
         [Obsolete("Actually refers to the entire support invite URL, not just its invite code. Use SupportUrl instead.")]
-        public string SupportInviteCode { get; set; }
+        public string SupportInviteCode => supportUrl;
 
         [JsonPropertyName("github")] public string githubUrl { get; set; }
 
@@ -79,9 +81,7 @@ namespace DiscordBotsList.Api.Internal
 
         public List<string> Tags => tags;
 
-#pragma warning disable CS0618
-        public string SupportUrl => SupportInviteCode;
-#pragma warning restore CS0618
+        public string SupportUrl => supportUrl;
 
         public string VanityUrl => "https://top.gg/bot/" + vanity;
 

--- a/DiscordBotsList.Api/Internal/BotReviews.cs
+++ b/DiscordBotsList.Api/Internal/BotReviews.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace DiscordBotsList.Api.Internal
+{
+    public class BotReviews
+    {
+        [JsonPropertyName("averageScore")]
+        public double AverageScore { get; internal set; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; internal set; }
+    }
+}

--- a/DiscordBotsList.Api/Internal/Entity.cs
+++ b/DiscordBotsList.Api/Internal/Entity.cs
@@ -9,11 +9,11 @@ namespace DiscordBotsList.Api.Internal
 
         [JsonPropertyName("defAvatar")] public string DefaultAvatar { get; set; }
 
-        public string AvatarUrl => !string.IsNullOrEmpty(Avatar)
-            ? $"https://cdn.discordapp.com/{Id}/{Avatar}.png"
-            : $"https://cdn.discordapp.com/{Id}/{DefaultAvatar}.png";
+        public string AvatarUrl => Avatar;
 
-        [JsonPropertyName("id")] public ulong Id { get; set; }
+        [JsonPropertyName("id")]
+        [JsonConverter(typeof(ULongToStringConverter))]
+        public ulong Id { get; set; }
 
         [JsonPropertyName("username")] public string Username { get; set; }
 

--- a/DiscordBotsList.Api/Internal/Queries/BotListQuery.cs
+++ b/DiscordBotsList.Api/Internal/Queries/BotListQuery.cs
@@ -12,7 +12,7 @@ namespace DiscordBotsList.Api.Internal.Queries
 
         [JsonPropertyName("limit")] public int limit { get; set; }
 
-        [JsonPropertyName("offset")] public int offset { get; set; }
+        [JsonPropertyName("offset")] public int? offset { get; set; }
 
         [JsonPropertyName("count")] public int count { get; set; }
 
@@ -22,7 +22,7 @@ namespace DiscordBotsList.Api.Internal.Queries
             .Cast<IDblBot>()
             .ToList();
 
-        public int CurrentPage => (int)Math.Ceiling((double)offset / limit);
+        public int CurrentPage => (int)Math.Ceiling((double)(offset ?? 0) / limit);
 
         public int ItemsPerPage => limit;
 

--- a/DiscordBotsList.Api/Internal/SelfBot.cs
+++ b/DiscordBotsList.Api/Internal/SelfBot.cs
@@ -6,9 +6,9 @@ namespace DiscordBotsList.Api.Internal
 {
     internal class SelfBot : Bot, IDblSelfBot
     {
-        public async Task<List<IDblEntity>> GetVotersAsync()
+        public async Task<List<IDblEntity>> GetVotersAsync(int page = 1)
         {
-            return await ((AuthDiscordBotListApi)api).GetVotersAsync();
+            return await ((AuthDiscordBotListApi)api).GetVotersAsync(page);
         }
 
         public async Task<bool> HasVotedAsync(ulong userId)

--- a/DiscordBotsList.Api/Objects/IDblBot.cs
+++ b/DiscordBotsList.Api/Objects/IDblBot.cs
@@ -24,7 +24,7 @@ namespace DiscordBotsList.Api.Objects
 
         string InviteUrl { get; }
 
-        DateTime ApprovedAt { get; }
+        DateTime SubmittedAt { get; }
 
         bool IsCertified { get; }
 

--- a/DiscordBotsList.Api/Objects/IDblBot.cs
+++ b/DiscordBotsList.Api/Objects/IDblBot.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DiscordBotsList.Api.Internal;
 
 namespace DiscordBotsList.Api.Objects
 {
     public interface IDblBot : IDblEntity
     {
+        ulong ClientId { get; }
+
+        string VanityTag { get; }
+        
         string PrefixUsed { get; }
 
         string ShortDescription { get; }
@@ -33,6 +38,8 @@ namespace DiscordBotsList.Api.Objects
         int Points { get; }
         
         int MonthlyPoints { get; }
+
+        BotReviews Reviews { get; }
 
         Task<IDblBotStats> GetStatsAsync();
     }

--- a/DiscordBotsList.Api/Objects/IDblBot.cs
+++ b/DiscordBotsList.Api/Objects/IDblBot.cs
@@ -46,7 +46,7 @@ namespace DiscordBotsList.Api.Objects
 
     public interface IDblSelfBot : IDblBot
     {
-        Task<List<IDblEntity>> GetVotersAsync();
+        Task<List<IDblEntity>> GetVotersAsync(int page = 1);
 
         Task<bool> HasVotedAsync(ulong userId);
 

--- a/DiscordBotsList.Api/Objects/IDblEntity.cs
+++ b/DiscordBotsList.Api/Objects/IDblEntity.cs
@@ -3,12 +3,12 @@
     public interface IDblEntity
     {
         /// <summary>
-        ///     Discord Id
+        ///     Id
         /// </summary>
         ulong Id { get; }
 
         /// <summary>
-        ///     Username of the entity
+        ///     Username
         /// </summary>
         string Username { get; }
 
@@ -18,7 +18,7 @@
         string Discriminator { get; }
 
         /// <summary>
-        ///     Discord avatar url, or default avatar if none found.
+        ///     Avatar url, or default avatar if none found.
         /// </summary>
         string AvatarUrl { get; }
     }

--- a/DiscordBotsList.Api/Objects/WeekendObject.cs
+++ b/DiscordBotsList.Api/Objects/WeekendObject.cs
@@ -1,7 +1,10 @@
-﻿namespace DiscordBotsList.Api.Objects
+﻿using System.Text.Json.Serialization;
+
+namespace DiscordBotsList.Api.Objects
 {
-    public struct WeekendObject
+    public class WeekendObject
     {
-        public bool Weekend;
+        [JsonPropertyName("is_weekend")]
+        public bool Weekend { get; set; }
     }
 }

--- a/DiscordBotsList.Api/Serialization/ULongToStringConverter.cs
+++ b/DiscordBotsList.Api/Serialization/ULongToStringConverter.cs
@@ -9,21 +9,17 @@ namespace DiscordBotsList.Api.Internal
     /// </summary>
     internal class ULongToStringConverter : JsonConverter<ulong>
     {
-        public override ulong Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
+        public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var stringValue = reader.GetString();
-            if (ulong.TryParse(stringValue, out var value)) return value;
+            if (reader.TokenType == JsonTokenType.String && ulong.TryParse(reader.GetString(), out var value))
+            {
+                return value;
+            }
 
             throw new InvalidOperationException();
         }
 
-        public override void Write(
-            Utf8JsonWriter writer,
-            ulong value,
-            JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(value.ToString());
         }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Discord Bots
+Copyright (c) 2019-2025 Discord Bots
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The following pull request is a toned down version of #29. This pull request focuses solely on adapting the SDK to the latest version of v0.

Notable changelogs:
- Move methods that actually require authentication from `DiscordBotListApi` to `AuthenticatedBotListApi`. The latter has been marked as obsolete.
- Remove useless `_token` private attribute.
- Bump many dependency versions.
- Replace oudated GitHub URL.
- Make the unit tests work.
- Update LICENSE year.
- Other minor refactors.

[This branch is already tested](https://discord.com/channels/264445053596991498/844289669118427226/1422173322472460478).